### PR TITLE
[#220] Fix Akvopedia shortcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ code/wp-content/uploads
 # Temporary files & directories
 code/wp-content/cache
 code/wp-content/plugins/global-admin-bar-hide-or-remove/error_log.txt
-code/wp-content/plugins/json-data/cache
+code/wp-content/plugins/json-data/cache/*/data*
+code/wp-content/plugins/json-data/cache/*/style*
 code/wp-content/plugins/wp-piwik/update
 code/wp-content/upgrade
 code/wp-snapshots

--- a/code/.htaccess
+++ b/code/.htaccess
@@ -2,11 +2,11 @@
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On
-RewriteBase /akvo-web-master/code/
+RewriteBase /
 RewriteRule ^index\.php$ - [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule . /akvo-web-master/code/index.php [L]
+RewriteRule . /index.php [L]
 </IfModule>
 
 # END WordPress

--- a/code/wp-content/plugins/json-data/cache/13/template.phtml
+++ b/code/wp-content/plugins/json-data/cache/13/template.phtml
@@ -1,0 +1,14 @@
+<ul class="rsrData dashData">
+  <li>
+    <h4>Projects:</h4>
+    <span ><?= $aData['number_of_projects']?></span> </li>
+  <li>
+    <h4>Number of updates:</h4>
+    <span ><?php do_shortcode('[jsondata_feed slug="rsr-update-count"]'); ?></span> </li>
+  <li>
+    <h4>Organisations Using RSR:</h4>
+    <span id=""><?= $aData['number_of_organisations']?></span> </li>
+  <li>
+    <h4>Project Budgets:</h4>
+    <span id="">€ <?= $aData['projects_budget_millions']?><span class="unit">million</span></span></li>
+</ul>

--- a/code/wp-content/plugins/json-data/cache/14/template.phtml
+++ b/code/wp-content/plugins/json-data/cache/14/template.phtml
@@ -1,0 +1,3 @@
+<?php
+  echo $aData['meta']['total_count'];
+?>

--- a/code/wp-content/plugins/json-data/cache/16/template.phtml
+++ b/code/wp-content/plugins/json-data/cache/16/template.phtml
@@ -1,0 +1,3 @@
+<?php
+	echo $aData['query']['statistics']['articles'];
+?>

--- a/code/wp-content/plugins/json-data/cache/17/template.phtml
+++ b/code/wp-content/plugins/json-data/cache/17/template.phtml
@@ -1,0 +1,3 @@
+<?php
+  echo $aData['meta']['total_count'];
+?>

--- a/code/wp-content/plugins/json-data/cache/18/template.phtml
+++ b/code/wp-content/plugins/json-data/cache/18/template.phtml
@@ -1,0 +1,3 @@
+<?php
+  echo $aData['meta']['total_count'];
+?>

--- a/code/wp-content/themes/Akvo-responsive/json_data_templates/akvopedia-analytics.template.php
+++ b/code/wp-content/themes/Akvo-responsive/json_data_templates/akvopedia-analytics.template.php
@@ -1,7 +1,7 @@
 
 <?php
 /*
-* Template for the "OpenAid orgs" plugin used on networkPage.php
+* Template for the "Akvopedia analytics" plugin used on networkPage.php
 * Feed name: Akvopedia analytics
 * Slug: akvopedia-analytics
 * JSON feed URL: http://analytics.akvo.org/index.php?module=API&method=API.get&idSite=9&period=range&date=2013-04-01,today&format=json&token_auth=1d1b520b11bea9a3b525b99531ec171a

--- a/code/wp-content/themes/Akvo-responsive/networkPage.php
+++ b/code/wp-content/themes/Akvo-responsive/networkPage.php
@@ -91,7 +91,7 @@
     </li>
     <li class="dashSingle" id="akvopediaDash">
       <h2>Akvopedia</h2>
-      <?php do_shortcode('[jsondata_feed slug="akvopedia-analytics"]'); ?>
+      <?php do_shortcode('[jsondata_feed slug="akvopedia-analytics" module="API" method="API.get" idSite="9" period="range" date="2013-04-01,today" format="json" token_auth="1d1b520b11bea9a3b525b99531ec171a"]'); ?>
       <a href="#"
          title="<p>How is this data collected? 'Articles' is collected automatically using the Mediawiki API ()
             The rest is collected automatically from the Piwik API ()</p>


### PR DESCRIPTION
The shortcode for the Akvopedia analytics was missing most of its arguments.

Comment fix inakvopedia-analytics.template.php.

Addition to .gitignore

Note that this fix doesn't help in terms of actually getting any data from the Piwik analytics API. See #257.
