### PR TITLE
[#236] Filter API for project map

### DIFF
--- a/code/wp-content/themes/Akvo-responsive/json_data_templates/rsr-project-global-map.template.php
+++ b/code/wp-content/themes/Akvo-responsive/json_data_templates/rsr-project-global-map.template.php
@@ -3,11 +3,11 @@
  * Template for the "RSR projects global map" plugin used on networkPage.php
  * Feed name: RSR projects map
  * Slug: rsr-projects-global-map
- * JSON feed URL: http://rsr.akvo.org/api/v1/map_for_project/?format=json&limit=1000
- * Resulting shortcode: [jsondata_feed slug="rsr-projects-global-map" offset="0" limit="1000" format="json"] and
- * [jsondata_feed slug="rsr-projects-global-map" offset="1000" limit="1000" format="json"]
+ * JSON feed URL: http://rsr.akvo.org/api/v1/map_for_project/?offset=0&limit=1000&status__in=N,H,A,C
+ * Resulting shortcode: [jsondata_feed slug="rsr-projects-global-map" status__in="N,H,A,C" limit="1000" offset="0"] and
+ * [jsondata_feed slug="rsr-projects-global-map" status__in="N,H,A,C" limit="1000" offset="1000"]
  * The two shortcodes are needed to pull all the data from RSR.
- * TODO: In the long run the need to pull twice is a problem since when RSR gets more than 2000 projects all data won't
+ * TODO: In the long run the need to pull twice is a problem since when we get to more than 2000 projects all data won't
  * be pulled
  */
 

--- a/code/wp-content/themes/Akvo-responsive/networkPage.php
+++ b/code/wp-content/themes/Akvo-responsive/networkPage.php
@@ -116,8 +116,8 @@
         mapTypeId: google.maps.MapTypeId.ROADMAP,
         streetViewControl: false
       },
-      projects: <?php do_shortcode('[jsondata_feed slug="rsr-projects-global-map" offset="0" limit="1000" format="json"]'); ?>,
-      projects2: <?php do_shortcode('[jsondata_feed slug="rsr-projects-global-map" offset="1000" limit="1000" format="json"]'); ?>,
+      projects: <?php do_shortcode('[jsondata_feed slug="rsr-projects-global-map" status__in="N,H,A,C" limit="1000" offset="0"]'); ?>,
+      projects2: <?php do_shortcode('[jsondata_feed slug="rsr-projects-global-map" status__in="N,H,A,C" limit="1000" offset="1000"]'); ?>,
 
       load: function() {
         var map = new google.maps.Map(this.canvas, this.options);


### PR DESCRIPTION
Add filter to the API call when fetching the projects to display on the
map on /seeithappen. Projects that are cancelled or archived are not
included.
