### PR TITLE
[#399] Implement DATA_DIR config variable in json-plugin

### DIFF
--- a/code/wp-content/plugins/json-data/json-data.php
+++ b/code/wp-content/plugins/json-data/json-data.php
@@ -29,6 +29,7 @@ define('JsonData_Plugin_Dir', dirname(__FILE__));
 define('JsonData_Plugin_Url', plugins_url('', __FILE__));
 define('JsonData_Plugin_File', __FILE__);
 define('JsonData_Plugin_DirFile', basename(dirname(__FILE__)) . '/' . basename(__FILE__));
+define('JsonData_Cache_Dir', DATA_DIR . 'json-data/cache/');
 
 require_once 'autoloader.php';
 JsonData\Controller::getInstance()->initialise();

--- a/code/wp-content/plugins/json-data/src/Admin/Model/FormHandler.php
+++ b/code/wp-content/plugins/json-data/src/Admin/Model/FormHandler.php
@@ -111,12 +111,12 @@ class FormHandler {
 			$aPopulateData['hiddenSlug'] = $aDetail['feed_slug'];
 			$aPopulateData['textUrl'] = $aDetail['feed_url'];
 			$aPopulateData['selectUpdateInterval'] = $aDetail['feed_update_interval'];
-            $filename = JsonData_Plugin_Dir . '/cache/'.$aDetail['feed_slug'].'/template.phtml';
+            $filename = JsonData_Cache_Dir . $aDetail['feed_slug'] . '/template.phtml';
             $handle = fopen($filename, "r");
             $contents = fread($handle, filesize($filename));
             fclose($handle);
 			$aPopulateData['textTemplateMarkup']= $contents;
-			$filename = JsonData_Plugin_Dir . '/cache/'.$aDetail['feed_slug'].'/style.css';
+			$filename = JsonData_Cache_Dir . $aDetail['feed_slug'] . '/style.css';
             $handle = fopen($filename, "r");
             $contents = fread($handle, filesize($filename));
             fclose($handle);

--- a/code/wp-content/plugins/json-data/src/Common/Model/Feed.php
+++ b/code/wp-content/plugins/json-data/src/Common/Model/Feed.php
@@ -8,15 +8,12 @@ use JsonData as JD;
  * @author Eveline Sparreboom
  */
 class Feed {
-    private $_sCacheDirName = null;
 
     public function __construct() {
-        $this->_sCacheDirName = JsonData_Plugin_Dir . DIRECTORY_SEPARATOR . 'cache';
-        if(!is_dir($this->_sCacheDirName)){
-            mkdir($this->_sCacheDirName,0777);
+        if(!is_dir(JsonData_Cache_Dir)){
+            mkdir(JsonData_Cache_Dir,0775);
         }
-        chmod($this->_sCacheDirName, 0777);
-
+        chmod(JsonData_Cache_Dir, 0775);
     }
 
     /**
@@ -24,15 +21,14 @@ class Feed {
      * @param int $iFeedId
      */
 	public function updateCreateCache($sFeedSlug,$sMarkup,$sStyle){
-        $sDirName = $this->_sCacheDirName. DIRECTORY_SEPARATOR .$sFeedSlug;
-        $sFeedMarkupFilename = $sDirName . DIRECTORY_SEPARATOR . 'template.phtml';
-        $sFeedStylesheetFilename = $sDirName . DIRECTORY_SEPARATOR . 'style.css';
-
+        $sDirName = JsonData_Cache_Dir . $sFeedSlug . DIRECTORY_SEPARATOR ;
+        $sFeedMarkupFilename = $sDirName . 'template.phtml';
+        $sFeedStylesheetFilename = $sDirName . 'style.css';
 
         if(!is_dir($sDirName)){
-            mkdir($sDirName,0777);
+            $foo = mkdir($sDirName,0775, true);
         }
-        chmod($sDirName, 0777);
+        chmod($sDirName, 0775);
 
         $fTemplate=fopen($sFeedMarkupFilename,'w+');
         fwrite($fTemplate, stripslashes($sMarkup));
@@ -42,8 +38,8 @@ class Feed {
         fwrite($fStylesheet, stripslashes($sStyle));
         fclose($fStylesheet);
 
-        chmod($sFeedMarkupFilename, 0777);
-        chmod($sFeedStylesheetFilename, 0777);
+        chmod($sFeedMarkupFilename, 0664);
+        chmod($sFeedStylesheetFilename, 0664);
 
     }
     /**
@@ -136,7 +132,6 @@ class Feed {
         $oDaoJsonData = new JsonDataDao();
         $iFeedId = $aFeed['feed_slug'];
         $aFeedQueues = $oDaoJsonData->fetchFeedQueue($iFeedId);
-        $sDirName = $this->_sCacheDirName. DIRECTORY_SEPARATOR .$iFeedId;
 
         //build url for queue
         $aUrl = explode('?',$aFeed['feed_url']);
@@ -162,7 +157,7 @@ class Feed {
             $aFeedQueue = $mQueue;
         }
         $iFeedId = $aFeed['feed_slug'];
-        $sDirName = $this->_sCacheDirName. DIRECTORY_SEPARATOR .$iFeedId;
+        $sDirName = JsonData_Cache_Dir . $iFeedId;
 
         //build url for queue
         $aUrl = explode('?',$aFeed['feed_url']);
@@ -194,16 +189,16 @@ class Feed {
     private function _removeQueueFiles($iFeedQueueId){
         $oDaoJsonData = new JsonDataDao();
         $aFeedQueue = $oDaoJsonData->fetchSingleFeedQueue($iFeedQueueId);
-        $sDirName = $this->_sCacheDirName. DIRECTORY_SEPARATOR .$aFeedQueue['json_data_id'];
+        $sDirName = JsonData_Cache_Dir . $aFeedQueue['json_data_id'] . DIRECTORY_SEPARATOR;
 
-        unlink($sDirName . DIRECTORY_SEPARATOR . 'data-' . $iFeedQueueId . '.json');
+        unlink($sDirName . 'data-' . $iFeedQueueId . '.json');
         $oDaoJsonData->deleteFeedQueue($iFeedQueueId);
     }
 
 	public function removeFeedDir ($iFeedId) {
 		$bStatus = false;
 
-		$sDirName = $this->_sCacheDirName . DIRECTORY_SEPARATOR . $iFeedId;
+		$sDirName = JsonData_Cache_Dir . DIRECTORY_SEPARATOR . $iFeedId . DIRECTORY_SEPARATOR;
 
 		if (is_dir($sDirName)) {
 			$oDirHandle = opendir($sDirName);
@@ -213,10 +208,10 @@ class Feed {
 
 					if ($oFile != "." && $oFile != "..") {
 
-						if (!is_dir($sDirName . DIRECTORY_SEPARATOR . $oFile)) {
-							unlink($sDirName . DIRECTORY_SEPARATOR . $oFile);
+						if (!is_dir($sDirName . $oFile)) {
+							unlink($sDirName . $oFile);
 						} else {
-							removeFeedDir($sDirName . DIRECTORY_SEPARATOR . $oFile);
+							removeFeedDir($sDirName . $oFile);
 						}
 					}
 				}

--- a/code/wp-content/plugins/json-data/src/Fe/Controller/Feed.php
+++ b/code/wp-content/plugins/json-data/src/Fe/Controller/Feed.php
@@ -57,9 +57,11 @@ class Feed {
             $iFeedQueueId = $aFeedDetail['id'];
             $oDaoJsonData->updateDisplayTime($iFeedQueueId);
             $this->enqueueFrontEndCss($iFeedId, $sFeedSlug);
-            $sData = file_get_contents(JsonData_Plugin_Dir . '/cache/'.$sFeedSlug.'/data-'.$iFeedQueueId.'.json');
+            $sData = file_get_contents(
+              JsonData_Cache_Dir . DIRECTORY_SEPARATOR . $sFeedSlug . DIRECTORY_SEPARATOR . 'data-'.$iFeedQueueId.'.json'
+            );
             $aData = json_decode($sData, true);
-            require JsonData_Plugin_Dir . '/cache/'.$sFeedSlug.'/template.phtml';
+            require JsonData_Cache_Dir . $sFeedSlug . DIRECTORY_SEPARATOR . 'template.phtml';
         }
 	}
 
@@ -69,7 +71,7 @@ class Feed {
 
 		$sHandle = AkvoWvwParticipantRegistry_Plugin_Slug . '-feed-'.$iFeedId.'-css';
 		if (!wp_style_is($sHandle, 'registered')) {
-			wp_register_style($sHandle, JsonData_Plugin_Url . '/cache/'.$sFeedSlug.'/style.css');
+			wp_register_style($sHandle, JsonData_Cache_Dir . $sFeedSlug . DIRECTORY_SEPARATOR . 'style.css');
 		}
 		if (!wp_style_is($sHandle, 'enqueued')) {
 			wp_enqueue_style($sHandle);

--- a/code/wp-content/themes/Akvo-responsive/json_data_templates/rsr-project-global-map.template.php
+++ b/code/wp-content/themes/Akvo-responsive/json_data_templates/rsr-project-global-map.template.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Template for the "RSR projects global map" plugin used on networkPage.php
- * Feed name: RSR projects map
+ * Feed name: RSR projects global map
  * Slug: rsr-projects-global-map
  * JSON feed URL: http://rsr.akvo.org/api/v1/map_for_project/?offset=0&limit=1000&status__in=N,H,A,C
  * Resulting shortcode: [jsondata_feed slug="rsr-projects-global-map" status__in="N,H,A,C" limit="1000" offset="0"] and


### PR DESCRIPTION
Modify the json-plugin to use the configuration variable DATA_DIR when
creating and accessing the plugins cache folder.

This is so the plugin templates can survive a deployment without the need
to re-instantiate them all.
