### PR TITLE
[#428] Fix base numbers for akvopedia stats

### DIFF
--- a/code/wp-content/themes/Akvo-responsive/json_data_templates/akvopedia-analytics.template.php
+++ b/code/wp-content/themes/Akvo-responsive/json_data_templates/akvopedia-analytics.template.php
@@ -20,10 +20,10 @@
   </li>
   <li>
     <h4>Page Views:</h4>
-    <span id=""><?= round((3201618 + $aData['nb_pageviews'])/1000)/1000 ?><span class="unit">million</span></span> </li>
+    <span id=""><?= round((2792519 + $aData['nb_pageviews'])/1000)/1000 ?><span class="unit">million</span></span> </li>
   <li>
     <h4>Visits:</h4>
-    <span id="number_of_visits"><?= $aData['nb_visits'] + 972014 ?></span> </li>
+    <span id="number_of_visits"><?= $aData['nb_visits'] + 737347 ?></span> </li>
   <li>
     <h4>More Stats soon</h4>
   </li>


### PR DESCRIPTION
The base numbers for the akvopedia page views and visits were changed
when the json-plugin wasn't working.

Now that the plugin works again we need to change them back.
