### PR TITLE
[#451] The following was the issue:

### DIFF
--- a/code/wp-content/plugins/json-data/src/Admin/Model/FormHandler.php
+++ b/code/wp-content/plugins/json-data/src/Admin/Model/FormHandler.php
@@ -111,15 +111,21 @@ class FormHandler {
 			$aPopulateData['hiddenSlug'] = $aDetail['feed_slug'];
 			$aPopulateData['textUrl'] = $aDetail['feed_url'];
 			$aPopulateData['selectUpdateInterval'] = $aDetail['feed_update_interval'];
+            $contents='';
             $filename = JsonData_Cache_Dir . $aDetail['feed_slug'] . '/template.phtml';
-            $handle = fopen($filename, "r");
-            $contents = fread($handle, filesize($filename));
-            fclose($handle);
+            if(file_exists($filename)){
+                $handle = fopen($filename, "r");
+                $contents = fread($handle, filesize($filename));
+                fclose($handle);
+            }
 			$aPopulateData['textTemplateMarkup']= $contents;
+            $contents='';
 			$filename = JsonData_Cache_Dir . $aDetail['feed_slug'] . '/style.css';
-            $handle = fopen($filename, "r");
-            $contents = fread($handle, filesize($filename));
-            fclose($handle);
+            if(file_exists($filename)){
+                $handle = fopen($filename, "r");
+                $contents = fread($handle, filesize($filename));
+                fclose($handle);
+            }
 			$aPopulateData['textTemplateStylesheet'] = $contents;
 
 

--- a/code/wp-content/plugins/json-data/src/Admin/View/scripts/forms/feed_manage.phtml
+++ b/code/wp-content/plugins/json-data/src/Admin/View/scripts/forms/feed_manage.phtml
@@ -115,14 +115,16 @@ if (!empty($aNameErrors)) {
                     <p><small>Once the URL has been entered, you may define the default values for the GET parameters here.</small></p>
 						
                     <div id="iDivAjaxReturn">
-                        <?php foreach($aFeedParams AS $sParamName=>$sParamValue){?>
-                            <div class="control-group " id="element-<?php echo $sParamName; ?>">
-                                <label class="control-label" for="textParam-<?php echo $sParamName; ?>"><?php echo $sParamName; ?></label>
-                                <div class="controls">
-                                    <input type="text" name="textParam[<?php echo $sParamName; ?>]" id="textParam-<?php echo $sParamName; ?>" value="<?php echo $sParamValue; ?>" class="input-xxlarge paramInput">
+                        <?php if($aFeedParams){
+                                foreach($aFeedParams AS $sParamName=>$sParamValue){?>
+                                <div class="control-group " id="element-<?php echo $sParamName; ?>">
+                                    <label class="control-label" for="textParam-<?php echo $sParamName; ?>"><?php echo $sParamName; ?></label>
+                                    <div class="controls">
+                                        <input type="text" name="textParam[<?php echo $sParamName; ?>]" id="textParam-<?php echo $sParamName; ?>" value="<?php echo $sParamValue; ?>" class="input-xxlarge paramInput">
+                                    </div>
                                 </div>
-                            </div>
-                        <?php } ?>
+                            <?php }
+                        }?>
                     </div>
                     <div id="iDivShortcodeExample">
                         

--- a/code/wp-content/plugins/json-data/src/Common/Model/Dao/JsonData.php
+++ b/code/wp-content/plugins/json-data/src/Common/Model/Dao/JsonData.php
@@ -201,6 +201,16 @@ class JsonData {
 		return $aIDs;
 	}
     
+    public function fetchAllFeedQueues () {
+		global $wpdb;
+
+		$sQuery = "SELECT jd.feed_slug,jdq.* FROM `" . $this->_sQueueTableName."` AS jdq"
+                . " JOIN `" . $this->_sTableName."` AS jd ON jdq.json_data_id = jd.id";
+        $aResults = $wpdb->get_results($sQuery, ARRAY_A);
+        
+		return $aResults;
+	}
+    
     public function fetchFeedQueue ($iFeedId) {
 		global $wpdb;
 

--- a/code/wp-content/plugins/json-data/src/Common/Model/Feed.php
+++ b/code/wp-content/plugins/json-data/src/Common/Model/Feed.php
@@ -13,7 +13,7 @@ class Feed {
         if(!is_dir(JsonData_Cache_Dir)){
             mkdir(JsonData_Cache_Dir,0775);
         }
-        chmod(JsonData_Cache_Dir, 0775);
+        @chmod(JsonData_Cache_Dir, 0775);
     }
 
     /**
@@ -80,34 +80,21 @@ class Feed {
     }
 
     /**
-     * remove unused shortcode feeds
+     * remove unused shortcode feed queues
      */
     public function cronRemove(){
         $oDaoJsonData = new JsonDataDao();
-        $aFeeds = $oDaoJsonData->fetchAllFeedQueueIDs();
-
-        $query = new \WP_Query(array('post_status'=>'any','posts_per_page'=>-1));
-        $aPosts = $query->get_posts();
-        $pattern = get_shortcode_regex();
-        ///get all used queues
-        $aUsedQueues = array();
-        foreach($aPosts AS $post){
-
-
-            if (   preg_match_all( '/'. $pattern .'/s', $post->post_content, $matches )
-                && array_key_exists( 2, $matches )
-                && in_array( JD\Config::SHORTCODE_JSON_DATA, $matches[2] ) )
-            {
-                foreach($matches[0] AS $sShortcode){
-                    $aParams = shortcode_parse_atts( $sShortcode );
-                    if(array_key_exists('id', $aParams)){
-                        $aUsedQueues[]=$aParams['id'];
-                    }
-                }
+        $aFeeds = $oDaoJsonData->fetchAllFeedQueues();
+        $aIdsToBeDeleted = array();
+        $aSlugsToBeDeleted = array();
+        foreach($aFeeds AS $aFeedQueue){
+            if(strtotime($aFeedQueue['last_display_time']) <= strtotime('-1 month')){
+                $aIdsToBeDeleted[]=$aFeedQueue['id'];
+                $aSlugsToBeDeleted[]=$aFeedQueue['feed_slug'];
             }
         }
-        $aToBeDeleted = array_diff($aFeeds, $aUsedQueues);
-        array_map(array(&$this,'_removeQueueFiles'),$aToBeDeleted);
+        
+        array_map(array(&$this,'_removeQueueFiles'),$aIdsToBeDeleted,$aSlugsToBeDeleted);
     }
 
     public function scheduleCron(){
@@ -166,9 +153,9 @@ class Feed {
         $iQueueId = $aFeedQueue['id'];
         $sQueueDataFilename = $sDirName . DIRECTORY_SEPARATOR . 'data-'.$iQueueId.'.json';
 
-        //$iFeedId = $aFeedQueue['json_data_id'];
+       
         $aQueueParams = unserialize($aFeedQueue['parameters']);
-        $sUrlParams = http_build_query($aQueueParams);
+        $sUrlParams = ($aQueueParams) ? http_build_query($aQueueParams) : '';
 
         $sQueueUrl=$sRootUrl.'?'.$sUrlParams;
 
@@ -185,12 +172,12 @@ class Feed {
     /**
      * remove unused queue
      * @param int $iFeedQueueId
+     * @param strin $sFeedSlug
      */
-    private function _removeQueueFiles($iFeedQueueId){
+    private function _removeQueueFiles($iFeedQueueId,$sFeedSlug){
         $oDaoJsonData = new JsonDataDao();
         $aFeedQueue = $oDaoJsonData->fetchSingleFeedQueue($iFeedQueueId);
-        $sDirName = JsonData_Cache_Dir . $aFeedQueue['json_data_id'] . DIRECTORY_SEPARATOR;
-
+        $sDirName = JsonData_Cache_Dir . $sFeedSlug . DIRECTORY_SEPARATOR;
         unlink($sDirName . 'data-' . $iFeedQueueId . '.json');
         $oDaoJsonData->deleteFeedQueue($iFeedQueueId);
     }
@@ -232,7 +219,9 @@ class Feed {
         if($aDetail){
             $aParams = unserialize($aDetail['feed_parameters']);
             $sParams= '';
-            foreach($aParams AS $k=>$v)$sParams.= ' '.$k.'="'.$v.'"';
+            if($aParams){
+                foreach($aParams AS $k=>$v)$sParams.= ' '.$k.'="'.$v.'"';
+            }
             $sShortcode = '[jsondata_feed slug="'.$slug.'"'.$sParams.']';
             $args=array(
                 'post_type' => 'jdata',

--- a/code/wp-content/plugins/json-data/src/Fe/Controller/Feed.php
+++ b/code/wp-content/plugins/json-data/src/Fe/Controller/Feed.php
@@ -24,17 +24,19 @@ class Feed {
         $aFeed = $oDaoJsonData->fetchFeedBySlug($sFeedSlug);
         $iFeedId = $aFeed['id'];
         $aDefaultParameters = unserialize($aFeed['feed_parameters']);
-        
-        ksort($aAttributes);
-        ksort($aDefaultParameters);
-        $aNewKeys = array_diff($aAttributes, $aDefaultParameters);
-        $aAllParams = array_merge($aDefaultParameters,$aNewKeys);
-        ksort($aAllParams);
-        $aAttributes = array_combine(array_keys($aAllParams),$aAttributes);
-        
-        ksort($aAttributes);
-        $sSerializedParameters= serialize($aAttributes);
-        
+        $sSerializedParameters = $aFeed['feed_parameters'];
+        if($aAttributes && $aDefaultParameters){
+            ksort($aAttributes);
+            ksort($aDefaultParameters);
+            $aNewKeys = array_diff($aAttributes, $aDefaultParameters);
+            $aAllParams = array_merge($aDefaultParameters,$aNewKeys);
+            ksort($aAllParams);
+
+            $aAttributes = array_combine(array_keys($aAllParams),$aAttributes);
+
+            ksort($aAttributes);
+            $sSerializedParameters= serialize($aAttributes);
+        }
 		$aFeedDetail = $oDaoJsonData->fetchSingleFeedQueueByParams($iFeedId,$sSerializedParameters);
         if(!$aFeedDetail){
             $aInsertData = array();
@@ -58,7 +60,7 @@ class Feed {
             $oDaoJsonData->updateDisplayTime($iFeedQueueId);
             $this->enqueueFrontEndCss($iFeedId, $sFeedSlug);
             $sData = file_get_contents(
-              JsonData_Cache_Dir . DIRECTORY_SEPARATOR . $sFeedSlug . DIRECTORY_SEPARATOR . 'data-'.$iFeedQueueId.'.json'
+              JsonData_Cache_Dir . $sFeedSlug . DIRECTORY_SEPARATOR . 'data-'.$iFeedQueueId.'.json'
             );
             $aData = json_decode($sData, true);
             require JsonData_Cache_Dir . $sFeedSlug . DIRECTORY_SEPARATOR . 'template.phtml';


### PR DESCRIPTION
The cronjob removes unused short codes by looking for short codes used in post content. If not found, it would remove the queue entry in the db and delete the files. Since no short codes are used in post content, this means the script attempted to remove all cache data files. By Murphy's law, the code that removes these files was wrong (it was looking for the old id folders, which is not working since we transferred to using the slug as the folder name). But the queue entry in the db was removed. So the cached files were never deleted and piling up.

I fixed it now, so after manually deleting the cached json files, they will be updated instead of piling up.

Also, the cronjob now checks the db queue entry for its last_update_time. If it is longer than 1 month ago, the file will be (successfully) deleted.
