### PR TITLE
[#581] add links for carousel images

### DIFF
--- a/code/wp-content/themes/Akvo-responsive/annual-report-2014.php
+++ b/code/wp-content/themes/Akvo-responsive/annual-report-2014.php
@@ -121,7 +121,9 @@
       <?php if( have_rows('ar_stories_items') ): ?>
         <?php while( have_rows('ar_stories_items') ): the_row(); ?>
           <li>
-            <img src="<?php the_sub_field('ar_story_image_url'); ?>">
+            <a href="<?php the_sub_field('ar_story_link_url'); ?>">
+              <img src="<?php the_sub_field('ar_story_image_url'); ?>">
+            </a>
           </li>      
         <?php endwhile; ?>
       <?php endif; ?>


### PR DESCRIPTION
#581 this PR adds the ability to create links for each carousel image

Note: if no link is specified for a carousel image, the image will be enclosed in an <a> tag with a blank href, which is bad