### PR TITLE
[#562]

### DIFF
--- a/code/wp-content/themes/Akvo-responsive/aboutUs.php
+++ b/code/wp-content/themes/Akvo-responsive/aboutUs.php
@@ -10,7 +10,7 @@
 <div id="content" class="floats-in aboutUsPag">
   <h1 class="backLined">About us</h1>
   <div class="wrapper" style="background:rgb(0,0,0); padding:1em 0 1em 0; margin:1em auto;">
-    <iframe width="800" height="450" frameborder="0" allowfullscreen="" mozallowfullscreen="" webkitallowfullscreen="" src="http://player.vimeo.com/video/56641129"></iframe>
+    <iframe width="800" height="450" frameborder="0" allowfullscreen="" mozallowfullscreen="" webkitallowfullscreen="" src="https://player.vimeo.com/video/56641129"></iframe>
     <p class="darkCenter"> Thomas Bjelkeman-Pettersson - Co-founder and co-director</p>
   </div>
   <div class="splitImgMid floats-in wrapper"> <a href="http://www.flickr.com/photos/charmermrk/sets/72157607214638092/with/2363864968/"> <img src="<?php bloginfo('template_directory'); ?>/images/postcards-400.jpg"> </a>
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="wrapper" style="background:rgb(0,0,0); padding:1em 0 1em 0; margin:1em auto;">
-    <iframe width="800" height="450" frameborder="0" allowfullscreen="" mozallowfullscreen="" webkitallowfullscreen="" src="http://player.vimeo.com/video/56645801?title=0&byline=0&portrait=0"></iframe>
+    <iframe width="800" height="450" frameborder="0" allowfullscreen="" mozallowfullscreen="" webkitallowfullscreen="" src="https://player.vimeo.com/video/56645801?title=0&byline=0&portrait=0"></iframe>
     <p class="darkCenter"> Peter Van Der Linde - Co-founder And Co-director </p>
   </div>
   <a href="/blog/the-akvo-platform-why-what-and-how/" class="seeMore moreLink">Learn more about how Akvo.org works</a> </div>

--- a/code/wp-content/themes/Akvo-responsive/annual-report-2014.php
+++ b/code/wp-content/themes/Akvo-responsive/annual-report-2014.php
@@ -261,14 +261,6 @@
       }
   });
 </script>
-<script>
- (function(d, t) {
-    var g = d.createElement(t),
-        s = d.getElementsByTagName(t)[0];
-    g.src = 'http://assets.gfycat.com/js/gfyajax-0.517d.js';
-    s.parentNode.insertBefore(g, s);
-}(document, 'script'));
-</script>
 <link rel="stylesheet" type="text/css" href="<?php echo get_template_directory_uri(); ?>/css/jquery.bxslider.css">
 <!-- end content --> 
 <?php get_footer();?>


### PR DESCRIPTION
Helps address some of the issues in #562. This PR sets the vimeo embeds on the About Us page to https, and removes an unnecessary script delivered over http in annual-report-2014
